### PR TITLE
Fixed FatalThrowableError when registering a new User

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -184,7 +184,7 @@ class AccountController extends BaseController
      * @param bool $newUser If is a New User
      * @return User
      */
-    public function createUser(Request $request, array $userInfo, bool $newUser = false): ?User
+    public function createUser(Request $request, array $userInfo, bool $newUser = false): User
     {
         $userName = $newUser ? uniqid(strstr($userInfo['email'], '@', true)) : $userInfo['username'];
         $userMail = $newUser ? $userInfo['email'] : $userInfo['mail'];


### PR DESCRIPTION
Just a tiny typo in the return type declaration, resulting in the weird recaptcha error some users were having