### PR TITLE
Best way to check invalid names

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -51,7 +51,7 @@ class AccountController extends BaseController
     protected function filterName(string $userName): bool
     {
         return count(array_filter(Config::get('chocolatey.invalid'), function ($username) use ($userName) {
-            return strpos($userName, $username) !== false;
+            return stripos($userName, $username) !== false;
         })) == 0;
     }
 


### PR DESCRIPTION
Correction to avoid bypassing invalid names using uppercase